### PR TITLE
Update install.bat

### DIFF
--- a/bin/install.bat
+++ b/bin/install.bat
@@ -3,7 +3,7 @@ if not exist "%~dp0RDPWInst.exe" goto :error
 "%~dp0RDPWInst" -i -o
 xcopy "%~dp0*" "C:\Program Files\RDP Wrapper\"  /s /I /y
 ping -n 3 localhost > nul
-SCHTASKS /CREATE /SC ONSTART /DELAY 0002:00 /TN "RDPWUpdater" /TR "C:\Program Files\RDP Wrapper\RDPWInst.exe -w" /RL HIGHEST /RU SYSTEM /NP
+SCHTASKS /CREATE /SC ONSTART /DELAY 0002:00 /TN "RDPWUpdater" /TR "'C:\Program Files\RDP Wrapper\RDPWInst.exe' -w" /RL HIGHEST /RU SYSTEM /NP
 cmd.exe /C start "" "C:\Program Files\RDP Wrapper\RDP_CnC.exe"
 exit
 :error


### PR DESCRIPTION
Fix for wrong path bug
Without the single quotes the scheduled task points to the path "C: \ Program" with the argument "Files\RDP Wrapper\RDPWInst.exe -w"