### PR TITLE
Fixed app starting position

### DIFF
--- a/src-RDP_CnC/MainUnit.dfm
+++ b/src-RDP_CnC/MainUnit.dfm
@@ -11,7 +11,7 @@ object MainForm: TMainForm
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  Position = poDesktopCenter
+  Position = poScreenCenter
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
   OnDestroy = FormDestroy


### PR DESCRIPTION
It was starting in the middle of the desktop instead of the middle of the screen.

If you have multiple monitors in weird locations, then `poDesktopCenter` will not work. `poScreenCenter` is the best option to use.