### PR TITLE
Modify the ini download address to ensure it is available in new rele…

### DIFF
--- a/src-installer/RDPWInst.dpr
+++ b/src-installer/RDPWInst.dpr
@@ -617,7 +617,7 @@ end;
 
 function GitINIFile(var Content: String; INI_source: String): Boolean;
 const
-  DEFAULT_URL = 'https://raw.githubusercontent.com/sebaxakerhtc/rdpwrap.ini/master/rdpwrap.ini';
+  DEFAULT_URL = 'https://github.moeyy.xyz/https://raw.githubusercontent.com/loyejaotdiqr47123/rdpwrap/master/res/rdpwrap.ini';
 var
   NetHandle: HINTERNET;
   UrlHandle: HINTERNET;


### PR DESCRIPTION
Modify the ini download address to ensure it is available in new releases.
For version 10.0.19041.1 and later, I recommend finding the offset of the function CUtils::IsSingleSessionPerUser(int *) , instead of the offset of CSessionArbitrationHelperMgr::IsSingleSessionPerUserEnabled , using the offset of CSessionArbitrationHelperMgr::IsSingleSessionPerUserEnabled , the first logged in user will be kicked out
Look [here](https://github.com/loyejaotdiqr47123/rdpwrap/commit/2c7ce6d94570c5327266062112e6d8b63f29db48)
We should look for memset and then mov xxx,1